### PR TITLE
fix for param parsing when passed as a 'plain object'

### DIFF
--- a/jquery.waitforimages.js
+++ b/jquery.waitforimages.js
@@ -46,9 +46,9 @@
 
         // Handle options object.
         if ($.isPlainObject(arguments[0])) {
-            finishedCallback = finishedCallback.finished;
-            eachCallback = finishedCallback.each;
-            waitForAll = finishedCallback.waitForAll;
+            finishedCallback = arguments[0].finished;
+            eachCallback = arguments[0].each;
+            waitForAll = arguments[0].waitForAll;
         }
 
         // Handle missing callbacks.


### PR DESCRIPTION
Hello,

I think there is a small bug parsing the params when you pass them as a single 'plain object' rather than itemized in a list.

Hope you find this useful and thanks for the code!

-mike
