### PR TITLE
Lack of unbind leads to memory leaks

### DIFF
--- a/src/jquery.waitforimages.js
+++ b/src/jquery.waitforimages.js
@@ -122,7 +122,9 @@
                 var image = new Image();
 
                 // Handle the image loading and error with the same callback.
-                $(image).bind('load.' + eventNamespace + ' error.' + eventNamespace, function (event) {
+                var eventName = 'load.' + eventNamespace + ' error.' + eventNamespace;
+                var $image = $(image)
+                $image.bind(eventName, function (event) {
                     allImgsLoaded++;
 
                     // If an error occurred with loading the image, set the third argument accordingly.
@@ -130,6 +132,7 @@
 
                     if (allImgsLoaded == allImgsLength) {
                         finishedCallback.call(obj[0]);
+                        $image.unbind(eventName)
                         return false;
                     }
 


### PR DESCRIPTION
Hi.
After all images are loaded there is no unbind. There is no reason to keep handlers binded. And because thees bindings comes from internal implementation there is no simple way user can remove them.
