### PR TITLE
Update jquery.waitforimages.js

### DIFF
--- a/src/jquery.waitforimages.js
+++ b/src/jquery.waitforimages.js
@@ -146,6 +146,7 @@
                         allImgs.push({
                             src: element.attr('src'),
                             srcset: element.attr('srcset'),
+                            sizes: element.attr('sizes'),
                             element: element[0]
                         });
                     });
@@ -169,7 +170,9 @@
                 finishedCallback.call(obj[0]);
                 deferred.resolveWith(obj[0]);
             }
-
+            
+            var has_srcset = ('srcset' in document.createElement('img')) && ('sizes' in document.createElement('img'));
+            
             $.each(allImgs, function (i, img) {
 
                 var image = new Image();
@@ -203,9 +206,11 @@
 
                 });
 
-                if (img.srcset) {
+                if (img.srcset && has_srcset) {
                     image.srcset = img.srcset;
+                    image.sizes = img.sizes;
                 }
+                
                 image.src = img.src;
             });
         });


### PR DESCRIPTION
Add proper support for srcset. The current implementation doesn't account for sizes and srcset without sizes downloads every image in srcset. CMS like WordPress do use srcset AND sizes. 

Further, I added a test to check if the browser actually supports srcset and sizes.