### PR TITLE
Added return-object with the total number of images found

### DIFF
--- a/src/jquery.waitforimages.js
+++ b/src/jquery.waitforimages.js
@@ -49,6 +49,7 @@
         var allImgsLength = 0;
         var allImgsLoaded = 0;
         var deferred = $.Deferred();
+        var retobj = {};
 
         var finishedCallback;
         var eachCallback;
@@ -163,6 +164,7 @@
 
             allImgsLength = allImgs.length;
             allImgsLoaded = 0;
+            retobj.allImgsLength = allImgs.length;
 
             // If no images found, don't bother.
             if (allImgsLength === 0) {
@@ -210,7 +212,7 @@
             });
         });
 
-        return deferred.promise();
+        return deferred.promise(retobj);
 
     };
 }));


### PR DESCRIPTION
I personally had an issue when loading multiple divs which may or may not have images inside.
Since I update a progressbar with a percentage-complete on the `each`-callback, this fails if there are no images.
So in the `finished`-callback I check if progress is complete, and then fade-out the loading-screen.

Example-code I use this in:
```JS
$('body .page-container').each(function(index, elem) {
  wfis[index] = $(elem).waitForImages({
	finished: function() {
	  var wfi = wfis[index];
	  if (typeof wfi === 'undefined') {
		progressperc += 1 / browser.vars.pages.length;
	  } else {
		console.log('finished with all ' + wfis[index].allImgsLength + ' images');
	  }
	  console.log(progressperc);
	  if (progressperc > 0.99) {
		NProgress.done();
		$loadingsvg.css('stroke-dashoffset', loadingmax - Math.abs(0 - (
			  loadingmax
			)));
		setTimeout(function() {
		  browser.goToPageIndex(browser.vars.current_pageindex, true, false);
		}, 1000);
	  }
	},
	each: function(loaded, count, success) {
	  progressperc += 1 / count / browser.vars.pages.length;
	  $loadingsvg.css('stroke-dashoffset', loadingmax - Math.abs(0 - (
			progressperc * loadingmax
		  )));
	  $loadingtext.text(Math.round(progressperc * 100) + '%');
	  NProgress.set(progressperc);
	},
	waitForAll: true
  });
});
```